### PR TITLE
Fix specs failing due to missing notify

### DIFF
--- a/spec/classes/spamassassin_spec.rb
+++ b/spec/classes/spamassassin_spec.rb
@@ -33,26 +33,26 @@ describe 'spamassassin' do
       it { should contain_file('/etc/mail/spamassassin/local.cf').with(
         :ensure  => 'present',
         :require => 'Package[spamassassin]',
-        :notify  => 'Service[spamassassin]'
+        :notify  => [],
         )
       }
 
       it { should contain_file('/etc/mail/spamassassin/v310.pre').with(
         :ensure  => 'present',
         :require => 'Package[spamassassin]',
-        :notify  => 'Service[spamassassin]'
+        :notify  => [],
         )
       }
       it { should contain_file('/etc/mail/spamassassin/v312.pre').with(
         :ensure  => 'present',
         :require => 'Package[spamassassin]',
-        :notify  => 'Service[spamassassin]'
+        :notify  => [],
         )
       }
       it { should contain_file('/etc/mail/spamassassin/v320.pre').with(
         :ensure  => 'present',
         :require => 'Package[spamassassin]',
-        :notify  => 'Service[spamassassin]'
+        :notify  => [],
         )
       }
 


### PR DESCRIPTION
The `service_enabled` parameter defaults to false, which caused these specs to fail.