### PR TITLE
Allow configuring the bayes_store_module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -186,8 +186,8 @@
 # tokens from the database. Default: true
 #
 # [*bayes_sql_enabled*]
-# Boolean. If true will set bayes_store_module to use sql and will write the
-# sql dsn, and other directives, to local.cf. Default: false
+# Boolean. If true will write the SQL-related directives to local.cf.
+# Default: false
 #
 # [*bayes_sql_dsn*]
 # This parameter gives the connect string used to connect to the SQL based
@@ -205,6 +205,14 @@
 # If this options is set the BayesStore::SQL module will override the set
 # username with the value given. This could be useful for implementing global
 # or group bayes databases.
+#
+# [*bayes_store_module*]
+# This parameter configures the module that spamassassin will use when
+# connecting to the Bayes SQL database. The default will work for most
+# database types, but selecting the module for a DBMS may result provide
+# performance improvements or additional features. Certain modules may
+# require the additional perl modules that are not installed by this Puppet
+# module.
 #
 # [*bayes_path*]
 # This is the directory and filename for Bayes databases. Please note this
@@ -444,6 +452,7 @@ class spamassassin(
   $bayes_sql_username                 = 'root',
   $bayes_sql_password                 = undef,
   $bayes_sql_override_username        = undef,
+  $bayes_store_module                 = 'Mail::SpamAssassin::BayesStore::SQL',
   $bayes_path                         = undef,
   $bayes_file_mode                    = undef,
   $bayes_auto_learn_threshold_nonspam = undef,

--- a/spec/classes/spamassassin_spec.rb
+++ b/spec/classes/spamassassin_spec.rb
@@ -249,6 +249,7 @@ describe 'spamassassin' do
           :bayes_sql_dsn      => 'DBI:mysql:spamassassin:localhost:3306',
           :bayes_sql_username => 'sqluser',
           :bayes_sql_password => 'somesecret',
+          :bayes_store_module => 'Mail::SpamAssassin::BayesStore::PgSQL',
         }}
 
         it { should contain_file('/etc/mail/spamassassin/local.cf').with({
@@ -259,6 +260,9 @@ describe 'spamassassin' do
         }
         it { should contain_file('/etc/mail/spamassassin/local.cf').with({
           'content' => /bayes_sql_password   somesecret/})
+        }
+        it { should contain_file('/etc/mail/spamassassin/local.cf').with({
+          'content' => /bayes_store_module   Mail::SpamAssassin::BayesStore::PgSQL/})
         }
       end
 

--- a/templates/local_cf.erb
+++ b/templates/local_cf.erb
@@ -90,7 +90,7 @@ bayes_auto_learn_threshold_spam <%= @bayes_auto_learn_threshold_spam %>
 bayes_ignore_header <%= val %>
 <% end -%>
 <% if @bayes_sql_enabled -%>
-bayes_store_module   Mail::SpamAssassin::BayesStore::SQL
+bayes_store_module   <%= @bayes_store_module %>
 bayes_sql_dsn        <%= @bayes_sql_dsn %>
 bayes_sql_username   <%= @bayes_sql_username %>
 bayes_sql_password   <%= @bayes_sql_password %>


### PR DESCRIPTION
Non-default modules can provide extra features or improved performance on some backends.

This version doesn't attempt to validate that the storage module [is valid](https://github.com/apache/spamassassin/tree/3.4/lib/Mail/SpamAssassin/BayesStore), or to install any required packages (e.g. `libdbd-pg-perl`).